### PR TITLE
direnv intigration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use flake
+use flake bsf/.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/buildsafedev/bsf/cmd/build"
 	"github.com/buildsafedev/bsf/cmd/configure"
 	"github.com/buildsafedev/bsf/cmd/develop"
+	"github.com/buildsafedev/bsf/cmd/direnv"
 	"github.com/buildsafedev/bsf/cmd/dockerfile"
 	initCmd "github.com/buildsafedev/bsf/cmd/init"
 	"github.com/buildsafedev/bsf/cmd/nixgenerate"
@@ -63,6 +64,7 @@ func Execute() {
 	rootCmd.AddCommand(scan.ScanCmd)
 	rootCmd.AddCommand(update.UpdateCmd)
 	rootCmd.AddCommand(attestation.AttCmd)
+	rootCmd.AddCommand(direnv.Direnv)
 
 	if os.Getenv("BSF_DEBUG_MODE") == "true" {
 		rootCmd.AddCommand(configure.ConfigureCmd)

--- a/cmd/direnv/direnv.go
+++ b/cmd/direnv/direnv.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -33,12 +32,6 @@ var Direnv = &cobra.Command{
 				fmt.Println(styles.ErrorStyle.Render("error: ", err.Error()))
 				os.Exit(1)
 			}
-		}
-
-		cmD := exec.Command("direnv", "allow")
-		err = cmD.Run()
-		if err != nil {
-			os.Exit(1)
 		}
 	},
 }
@@ -69,7 +62,6 @@ func generateEnvrc() error {
 
 			_, err = file.WriteString("\nuse flake bsf/.")
 			if err != nil {
-				fmt.Println(styles.ErrorStyle.Render("", err.Error()))
 				return err
 			}
 			return nil
@@ -107,7 +99,6 @@ func fetchGitignore() error {
 			file, err := os.OpenFile(".gitignore", os.O_APPEND|os.O_WRONLY, 0644)
 			_, err = file.WriteString("\n.envrc")
 			if err != nil {
-				fmt.Println(styles.ErrorStyle.Render("", err.Error()))
 				return err
 			}
 		}
@@ -148,12 +139,6 @@ func setDIrenv(args string) error {
 	_, err = file.WriteString("\nexport " + args)
 	if err != nil {
 		fmt.Println(styles.ErrorStyle.Render("", err.Error()))
-		return err
-	}
-
-	cmd := exec.Command("direnv", "allow")
-	err = cmd.Run()
-	if err != nil {
 		return err
 	}
 

--- a/cmd/direnv/direnv.go
+++ b/cmd/direnv/direnv.go
@@ -1,0 +1,163 @@
+package direnv
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/buildsafedev/bsf/cmd/styles"
+	"github.com/spf13/cobra"
+)
+
+var Direnv = &cobra.Command{
+	Use:   "direnv",
+	Short: "direnv initializes the direnv environment for the project",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := generateEnvrc()
+		if err != nil {
+			fmt.Println(styles.ErrorStyle.Render("error: ", err.Error()))
+			os.Exit(1)
+		}
+		err = fetchGitignore()
+		if err != nil {
+			fmt.Println(styles.ErrorStyle.Render("error: ", err.Error()))
+			os.Exit(1)
+		}
+
+		if envVar != "" {
+			err = setDIrenv(envVar)
+			if err != nil {
+				fmt.Println(styles.ErrorStyle.Render("error: ", err.Error()))
+				os.Exit(1)
+			}
+		}
+	},
+}
+
+var (
+	envVar string
+)
+
+func init() {
+	Direnv.Flags().StringVarP(&envVar, "env", "e", "", "set environment variable [key=value]")
+}
+
+func generateEnvrc() error {
+
+	if _, err := os.Stat(".envrc"); err == nil {
+
+		read, err := os.ReadFile(".envrc")
+		if err != nil {
+			return err
+		}
+
+		if !strings.Contains(string(read), "use flake bsf/.") {
+
+			file, err := os.OpenFile(".envrc", os.O_APPEND|os.O_WRONLY, 0644)
+			if err != nil {
+				return err
+			}
+
+			_, err = file.WriteString("\nuse flake bsf/.")
+			if err != nil {
+				fmt.Println(styles.ErrorStyle.Render("", err.Error()))
+				return err
+			}
+			return nil
+		}
+		fmt.Println(styles.HelpStyle.Render(" ✅ .envrc already exists"))
+
+	} else {
+		file, err := os.Create(".envrc")
+		if err != nil {
+			return err
+		}
+
+		defer file.Close()
+
+		_, err = file.WriteString("use flake bsf/.")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(styles.HelpStyle.Render(" ✅ .envrc generated"))
+
+		cmd := exec.Command("direnv", "allow")
+		err = cmd.Run()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func fetchGitignore() error {
+
+	if _, err := os.Stat(".gitignore"); err == nil {
+
+		read, err := os.ReadFile(".gitignore")
+		if err != nil {
+			return err
+		}
+
+		if !strings.Contains(string(read), ".envrc") {
+
+			file, err := os.OpenFile(".gitignore", os.O_APPEND|os.O_WRONLY, 0644)
+			_, err = file.WriteString("\n.envrc")
+			if err != nil {
+				fmt.Println(styles.ErrorStyle.Render("", err.Error()))
+				return err
+			}
+		}
+		fmt.Println(styles.HelpStyle.Render(" ✅ .gitignore already exists"))
+
+		return nil
+	} else {
+		_, err := os.Create(".gitignore")
+		if err != nil {
+			return err
+		}
+
+		file, err := os.OpenFile(".gitignore", os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			return err
+		}
+
+		_, err = file.WriteString("\n.envrc")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(styles.HelpStyle.Render(" ✅ .gitignore generated"))
+	}
+
+	return nil
+
+}
+
+func setDIrenv(args string) error {
+
+	if !strings.Contains(args, "=") {
+		return fmt.Errorf("Hint: use --env key=value")
+	} else {
+		file, err := os.OpenFile(".envrc", os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			return err
+		}
+
+		_, err = file.WriteString("\nexport " + args)
+		if err != nil {
+			fmt.Println(styles.ErrorStyle.Render("", err.Error()))
+			return err
+		}
+
+		cmd := exec.Command("direnv", "allow")
+		err = cmd.Run()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/direnv/direnv.go
+++ b/cmd/direnv/direnv.go
@@ -27,7 +27,7 @@ var Direnv = &cobra.Command{
 		}
 
 		if envVar != "" {
-			err = setDIrenv(envVar)
+			err = setDirenv(envVar)
 			if err != nil {
 				fmt.Println(styles.ErrorStyle.Render("error: ", err.Error()))
 				os.Exit(1)
@@ -68,20 +68,12 @@ func generateEnvrc() error {
 		}
 
 	} else {
-		file, err := os.Create(".envrc")
-		if err != nil {
-			return err
-		}
-
-		defer file.Close()
-
-		_, err = file.WriteString("use flake bsf/.")
+		err = os.WriteFile(".envrc", []byte("use flake bsf/."), 0644)
 		if err != nil {
 			return err
 		}
 
 	}
-
 	return nil
 }
 
@@ -105,17 +97,7 @@ func fetchGitignore() error {
 
 		return nil
 	} else {
-		_, err := os.Create(".gitignore")
-		if err != nil {
-			return err
-		}
-
-		file, err := os.OpenFile(".gitignore", os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			return err
-		}
-
-		_, err = file.WriteString("\n.envrc")
+		err = os.WriteFile(".gitignore", []byte(".envrc"), 0644)
 		if err != nil {
 			return err
 		}
@@ -125,7 +107,7 @@ func fetchGitignore() error {
 
 }
 
-func setDIrenv(args string) error {
+func setDirenv(args string) error {
 
 	err := validateEnvVars(args)
 	if err != nil {
@@ -165,15 +147,6 @@ func validateEnvVars(args string) error {
 
 		if strings.ContainsAny(value, "\x00") {
 			return errors.New("Invalid characters in value")
-		}
-
-		read, err := os.ReadFile(".envrc")
-		if err != nil {
-			return err
-		}
-
-		if strings.Contains(string(read), key) {
-			return errors.New("Key already exists")
 		}
 	}
 

--- a/cmd/direnv/direnv_test.go
+++ b/cmd/direnv/direnv_test.go
@@ -1,0 +1,56 @@
+package direnv
+
+import (
+	"testing"
+)
+
+func TestValidateEnvVars(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    string
+		wantErr bool
+	}{
+		{
+			name:    "Valid env vars",
+			args:    "KEY1=value1,KEY2=value2",
+			wantErr: false,
+		},
+		{
+			name:    "Invalid format (no value)",
+			args:    "KEY1=value1,KEY2",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid format (no key)",
+			args:    "=value1,KEY2=value2",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid format (empty)",
+			args:    "",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid format (no equals sign)",
+			args:    "KEY1value1,KEY2=value2",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid characters in key",
+			args:    "KEY1 =value1,KEY2=value2",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid characters in value",
+			args:    "KEY1=value1,KEY2=value\x00",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateEnvVars(tt.args); (err != nil) != tt.wantErr {
+				t.Errorf("validateEnvVars() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -72,7 +72,7 @@ func GetBSFInitializers() (bsfv1.SearchServiceClient, *hcl2nix.FileHandlers, err
 }
 
 // CleanUp removes the bsf config if any error occurs in init process (ctrl+c or any init process stage)
-func cleanUp(){
+func cleanUp() {
 	configs := []string{"bsf", "bsf.hcl", "bsf.lock"}
 
 	for _, f := range configs {

--- a/cmd/init/model.go
+++ b/cmd/init/model.go
@@ -73,7 +73,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	err = m.processStages(m.stage)
 	if err != nil {
-		 cleanUp()
+		cleanUp()
 		return m, tea.Quit
 	}
 	m.stage++

--- a/cmd/precheck/precheck.go
+++ b/cmd/precheck/precheck.go
@@ -71,60 +71,11 @@ func IsFlakesEnabled() {
 	}
 }
 
-// generates .envrc for Direnv intigration
-func generateEnvrc() error {
-
-	if _, err := os.Stat(".envrc"); err == nil {
-
-		read, err := os.ReadFile(".envrc")
-		if err != nil {
-			fmt.Println(styles.ErrorStyle.Render("", err.Error()))
-			os.Exit(1)
-		}
-
-		if !strings.Contains(string(read), "use flake bsf/.") {
-
-			file, err := os.OpenFile(".envrc", os.O_APPEND|os.O_WRONLY, 0644)
-			if err != nil {
-				fmt.Println(styles.ErrorStyle.Render("", err.Error()))
-				os.Exit(1)
-			}
-
-			_, err = file.WriteString("\nuse flake bsf/.")
-			if err != nil {
-				fmt.Println(styles.ErrorStyle.Render("", err.Error()))
-				os.Exit(1)
-			}
-			return nil
-		}
-		fmt.Println(styles.HelpStyle.Render(" ✅ .envrc already exists"))
-
-	} else {
-		file, err := os.Create(".envrc")
-		if err != nil {
-			fmt.Println(styles.ErrorStyle.Render("", err.Error()))
-			os.Exit(1)
-		}
-
-		defer file.Close()
-
-		_, err = file.WriteString("use flake bsf/.")
-		if err != nil {
-			fmt.Println(styles.ErrorStyle.Render("", err.Error()))
-			os.Exit(1)
-		}
-	}
-
-	fmt.Println(styles.HelpStyle.Render(" ✅ .envrc generated"))
-
-	return nil
-}
-
 // AllPrechecks runs all the prechecks
 func AllPrechecks() {
 	fmt.Println(styles.TextStyle.Render("Running prechecks..."))
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(2)
 	go func() {
 		ValidateNixVersion()
 		wg.Done()
@@ -134,11 +85,6 @@ func AllPrechecks() {
 		wg.Done()
 
 	}()
-	go func() {
-		generateEnvrc()
-		wg.Done()
-	}()
-
 	wg.Wait()
 
 	fmt.Println(styles.SucessStyle.Render(" Prechecks ran successfully"))

--- a/cmd/precheck/precheck.go
+++ b/cmd/precheck/precheck.go
@@ -71,6 +71,55 @@ func IsFlakesEnabled() {
 	}
 }
 
+// generates .envrc for Direnv intigration
+func generateEnvrc() error {
+
+	if _, err := os.Stat(".envrc"); err == nil {
+
+		read, err := os.ReadFile(".envrc")
+		if err != nil {
+			fmt.Println(styles.ErrorStyle.Render("", err.Error()))
+			os.Exit(1)
+		}
+
+		if !strings.Contains(string(read), "use flake bsf/.") {
+
+			file, err := os.OpenFile(".envrc", os.O_APPEND|os.O_WRONLY, 0644)
+			if err != nil {
+				fmt.Println(styles.ErrorStyle.Render("", err.Error()))
+				os.Exit(1)
+			}
+
+			_, err = file.WriteString("\nuse flake bsf/.")
+			if err != nil {
+				fmt.Println(styles.ErrorStyle.Render("", err.Error()))
+				os.Exit(1)
+			}
+			return nil
+		}
+		fmt.Println(styles.HelpStyle.Render(" ✅ .envrc already exists"))
+
+	} else {
+		file, err := os.Create(".envrc")
+		if err != nil {
+			fmt.Println(styles.ErrorStyle.Render("", err.Error()))
+			os.Exit(1)
+		}
+
+		defer file.Close()
+
+		_, err = file.WriteString("use flake bsf/.")
+		if err != nil {
+			fmt.Println(styles.ErrorStyle.Render("", err.Error()))
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println(styles.HelpStyle.Render(" ✅ .envrc generated"))
+
+	return nil
+}
+
 // AllPrechecks runs all the prechecks
 func AllPrechecks() {
 	fmt.Println(styles.TextStyle.Render("Running prechecks..."))
@@ -86,8 +135,8 @@ func AllPrechecks() {
 
 	}()
 	go func() {
+		generateEnvrc()
 		wg.Done()
-
 	}()
 
 	wg.Wait()


### PR DESCRIPTION
use:
   `bsf direnv` -> initilizes current dir with  .envrc and .gitignore 
   `bsf direnv --env key=value` -> sets the env in .envrc

by doing `bsf direnv`  direnv files get loaded in the current dir and whenever user opens shell in the current dir ,
it always opens nix dev shell without specifying any argument

[✔️ ] test locally