### PR TITLE
Fix docker load on systems where context isn't in ~/.docker

### DIFF
--- a/cmd/oci/oci.go
+++ b/cmd/oci/oci.go
@@ -120,27 +120,32 @@ var OCICmd = &cobra.Command{
 		if loadDocker {
 			fmt.Println(styles.HighlightStyle.Render("Loading image to docker daemon..."))
 
+			expectedInstall := true
 			currentContext, err := builddocker.GetCurrentContext()
 			if err != nil {
-				fmt.Println(styles.ErrorStyle.Render("error:", err.Error()))
-				os.Exit(1)
+				expectedInstall = false
 			}
 			contextEP, err := builddocker.ReadContextEndpoints()
 			if err != nil {
-				fmt.Println(styles.ErrorStyle.Render("error:", err.Error()))
-				os.Exit(1)
+				expectedInstall = false
 			}
 			if currentContext == "" {
 				currentContext = "default"
 			}
+			if contextEP == nil {
+				contextEP = make(map[string]string)
+			}
+
 			if _, ok := contextEP[currentContext]; !ok {
 				contextEP[currentContext] = "unix:///var/run/docker.sock"
 			}
-			_ = currentContext
 
 			err = oci.LoadDocker(contextEP[currentContext], output+"/result", env.Name)
 			if err != nil {
 				fmt.Println(styles.ErrorStyle.Render("error:", err.Error()))
+				if !expectedInstall {
+					fmt.Println(styles.ErrorStyle.Render("error:", "Is Docker installed?"))
+				}
 				os.Exit(1)
 			}
 

--- a/pkg/builddocker/context.go
+++ b/pkg/builddocker/context.go
@@ -2,7 +2,6 @@ package builddocker
 
 // source for this file- https://github.com/project-copacetic/copacetic/blob/main/pkg/buildkit/drivers.go
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -13,7 +12,7 @@ import (
 func GetCurrentContext() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		fmt.Println("Error getting user home directory:", err)
+
 		return "", err
 	}
 
@@ -21,14 +20,12 @@ func GetCurrentContext() (string, error) {
 
 	data, err := os.ReadFile(dockerConfigPath)
 	if err != nil {
-		fmt.Println("Error reading Docker config file:", err)
 		return "", err
 	}
 
 	// Get the current context from the Docker config file
 	currentContext := gjson.GetBytes(data, "currentContext").String()
 	if currentContext == "" {
-		fmt.Println("No current Docker context found")
 		return "", err
 	}
 
@@ -40,13 +37,11 @@ func GetCurrentContext() (string, error) {
 func ReadContextEndpoints() (map[string]string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		fmt.Println("Error getting user home directory:", err)
 		return nil, err
 	}
 
 	files, err := os.ReadDir(homeDir + "/.docker/contexts/meta")
 	if err != nil {
-		fmt.Println("Error reading Docker context meta directory:", err)
 		return nil, err
 	}
 
@@ -57,7 +52,6 @@ func ReadContextEndpoints() (map[string]string, error) {
 		}
 		data, err := os.ReadFile(homeDir + "/.docker/contexts/meta/" + file.Name() + "/meta.json")
 		if err != nil {
-			fmt.Println("Error reading Docker context meta file:", err)
 			return nil, err
 		}
 		contextName := gjson.GetBytes(data, "Name").String()


### PR DESCRIPTION
 On certain linux systems, `.docker/config.json` and `contexts` aren't present.  This PR attemps to load it directly in such systems and if it fails & questions user if they've Docker installed. 
 
 Also, removes print statements from pkg as we don't want pkgs to log (without being configurable when we do)