### PR TITLE
Modify flake to use no cc

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
     in
     {
       packages = forEachSystem ({ pkgs, ... }: {
-        default = pkgs.stdenv.mkDerivation rec {
+        default = pkgs.stdenvNoCC.mkDerivation  rec {
           name = "bsf";
           version = "0.1";
 


### PR DESCRIPTION
Switching flake to use no cc(gcc,etc) to reduce the dependencies fetch to download bsf binary. 
