### PR TITLE
[fix] when project isn't at git repo root

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,11 @@
         "mode": "auto",
         "program": "${workspaceFolder}/main.go",
         "args": ["build"],
+        "env": {
+            "BSF_DEBUG": "true",
+            "BSF_DEBUG_DIR": "/Users/house/Desktop/buildsafe/examples/go-server-example",
+        },
+        "console": "integratedTerminal"
     }
     ]
 }


### PR DESCRIPTION
When project isn't at git repo's root, we initialised git again despite the project/directory being part of a git repository already. This PR aims to fix that bug. This might be our first step to help with monorepo setups