### PR TITLE
load-podman

### DIFF
--- a/cmd/oci/oci.go
+++ b/cmd/oci/oci.go
@@ -22,8 +22,8 @@ import (
 )
 
 var (
-	platform, output string
-	push, loadDocker bool
+	platform, output             string
+	push, loadDocker, loadPodman bool
 )
 var (
 	supportedPlatforms = []string{"linux/amd64", "linux/arm64"}
@@ -154,6 +154,16 @@ var OCICmd = &cobra.Command{
 
 		}
 
+		if loadPodman {
+			fmt.Println(styles.HighlightStyle.Render("Loading image to podman..."))
+			err = oci.LoadPodman(output+"/result", env.Name)
+			if err != nil {
+				fmt.Println(styles.ErrorStyle.Render("error:", err.Error()))
+				os.Exit(1)
+			}
+			fmt.Println(styles.SucessStyle.Render(fmt.Sprintf("Image %s loaded to podman", env.Name)))
+		}
+
 		if push {
 			fmt.Println(styles.HighlightStyle.Render("Pushing image to registry..."))
 			err = oci.Push(output+"/result", env.Name)
@@ -248,6 +258,7 @@ func init() {
 	OCICmd.Flags().StringVarP(&platform, "platform", "p", "", "The platform to build the image for")
 	OCICmd.Flags().StringVarP(&output, "output", "o", "", "location of the build artifacts generated")
 	OCICmd.Flags().BoolVarP(&loadDocker, "load-docker", "", false, "Load the image into docker daemon")
+	OCICmd.Flags().BoolVarP(&loadPodman, "load-podman", "", false, "Load the image into podman")
 	OCICmd.Flags().BoolVarP(&push, "push", "", false, "Push the image to the registry")
 
 }

--- a/pkg/oci/skopeo.go
+++ b/pkg/oci/skopeo.go
@@ -18,6 +18,19 @@ func LoadDocker(daemon, dir, imageName string) error {
 	return nil
 }
 
+// LoadPodman loads the image to the poadman
+func LoadPodman(dir, imageName string) error {
+	cmd := exec.Command("nix", "run", "nixpkgs#skopeo", "--", "copy", "--insecure-policy", "dir:"+dir, "containers-storage:"+imageName)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Push image to registry
 func Push(dir, imageName string) error {
 	cmd := exec.Command("nix", "run", "nixpkgs#skopeo", "--", "copy", "--insecure-policy", "dir:"+dir, "docker://"+imageName)


### PR DESCRIPTION
load podman lets the user load there oci images in podman
uses: 

`bsf oci dev --load-podman`

- [✅ ] Tested locally 

```
warning: Git tree '/home/holiodin/bsf' is dirty
Generating artifacts...
Build completed successfully, please check the bsf-result directory
Loading image to podman...
Getting image source signatures
Copying blob 4cd11ea234bf done   | 
Copying blob 273721342111 done   | 
Copying blob 693a8385a860 done   | 
Copying blob 87ca5b94847d done   | 
Copying blob 9e3ac58ba8ca done   | 
Copying blob 63d7561148dc done   | 
Copying blob 566cacc0e826 done   | 
Copying blob f4909d4bd075 done   | 
Copying blob 51354d3d8115 done   | 
Copying config c71ae52a26 done   | 
Writing manifest to image destination
Image ttl.sh/buildsafe/goapp:dev loaded to podman
holiodin@fedora:~/bsf$ podman images
REPOSITORY              TAG         IMAGE ID      CREATED         SIZE
ttl.sh/buildsafe/goapp  dev         c71ae52a26b6  18 seconds ago  63 MB
```