### PR TITLE
fix: oci cmd for tag

### DIFF
--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -48,7 +48,7 @@ var BuildCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		err = generate.Generate(fh, sc, nil)
+		err = generate.Generate(fh, sc)
 		if err != nil {
 			fmt.Println(styles.ErrorStyle.Render("error: ", err.Error()))
 			os.Exit(1)

--- a/cmd/develop/develop.go
+++ b/cmd/develop/develop.go
@@ -26,7 +26,7 @@ var DevCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		err = generate.Generate(fh, sc, nil)
+		err = generate.Generate(fh, sc)
 		if err != nil {
 			fmt.Println(styles.ErrorStyle.Render("error: ", err.Error()))
 			os.Exit(1)

--- a/cmd/dockerfile/df.go
+++ b/cmd/dockerfile/df.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildsafedev/bsf/pkg/builddocker"
 	"github.com/buildsafedev/bsf/pkg/generate"
 	bgit "github.com/buildsafedev/bsf/pkg/git"
+	"github.com/buildsafedev/bsf/pkg/hcl2nix"
 )
 
 var (
@@ -40,7 +41,13 @@ var DFCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		env, p, err := ocicmd.ProcessPlatformAndConfig(platform, args[0])
+		conf, err := hcl2nix.ReadHclFile("bsf.hcl")
+		if err != nil {
+			fmt.Println(styles.ErrorStyle.Render("error: ", err.Error()))
+			os.Exit(1)
+		}
+
+		env, p, err := ocicmd.ProcessPlatformAndConfig(conf, platform, args[0])
 		if err != nil {
 			fmt.Println(styles.ErrorStyle.Render("error: ", err.Error()))
 			os.Exit(1)
@@ -53,7 +60,7 @@ var DFCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		err = generate.Generate(fh, sc, nil)
+		err = generate.Generate(fh, sc)
 		if err != nil {
 			fmt.Println(styles.ErrorStyle.Render("error: ", err.Error()))
 			os.Exit(1)

--- a/cmd/init/model.go
+++ b/cmd/init/model.go
@@ -128,7 +128,7 @@ func (m *model) processStages(stage int) error {
 			return err
 		}
 
-		err = generate.Generate(fh, m.sc, nil)
+		err = generate.Generate(fh, m.sc)
 		if err != nil {
 			m.stageMsg = errorStyle(err.Error())
 			return err

--- a/cmd/nixgenerate/model.go
+++ b/cmd/nixgenerate/model.go
@@ -92,7 +92,7 @@ func (m *model) processStages(stage int) error {
 		defer fh.FlakeFile.Close()
 		defer fh.DefFlakeFile.Close()
 
-		err = generate.Generate(fh, m.sc, nil)
+		err = generate.Generate(fh, m.sc)
 		if err != nil {
 			m.stageMsg = errorStyle("Failed to generate files: ", err.Error())
 			return err

--- a/cmd/release/release.go
+++ b/cmd/release/release.go
@@ -1,7 +1,6 @@
 package release
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -50,15 +49,7 @@ var ReleaseCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		data, err := os.ReadFile("bsf.hcl")
-		if err != nil {
-			fmt.Println(styles.ErrorStyle.Render("error: ", "failed to read config"))
-			fmt.Println(styles.HintStyle.Render("hint:", "run `bsf init` "))
-			os.Exit(1)
-		}
-
-		var dstErr bytes.Buffer
-		conf, err := hcl2nix.ReadConfig(data, &dstErr)
+		conf, err := hcl2nix.ReadHclFile("bsf.hcl")
 		if err != nil {
 			fmt.Println(styles.ErrorStyle.Render("error: ", "failed to read config"))
 			fmt.Println(styles.HintStyle.Render("hint:", "run `bsf init` "))

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -98,7 +98,7 @@ var UpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		err = generate.Generate(fh, sc, nil)
+		err = generate.Generate(fh, sc)
 		if err != nil {
 			fmt.Println(styles.ErrorStyle.Render("Error generating files: %s", err.Error()))
 			os.Exit(1)

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -1,7 +1,6 @@
 package generate
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -17,31 +16,16 @@ import (
 )
 
 // Generate reads bsf.hcl, resolves dependencies and generates bsf.lock, bsf/flake.nix, bsf/default.nix, etc.
-func Generate(fh *hcl2nix.FileHandlers, sc buildsafev1.SearchServiceClient, nameMap map[string]string) error {
-	data, err := os.ReadFile("bsf.hcl")
+func Generate(fh *hcl2nix.FileHandlers, sc buildsafev1.SearchServiceClient) error {
+	conf, err := hcl2nix.ReadHclFile("bsf.hcl")
 	if err != nil {
 		return err
-	}
-
-	var dstErr bytes.Buffer
-	conf, err := hcl2nix.ReadConfig(data, &dstErr)
-	if err != nil {
-		return fmt.Errorf("%v", &dstErr)
-	}
-
-	if len(nameMap) > 0 {
-		for i, artifact := range conf.OCIArtifact {
-			if newName, ok := nameMap[artifact.Name]; ok {
-				conf.OCIArtifact[i].Name = newName
-			}
-		}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 	defer cancel()
 
 	pkgType := getPkgType(conf)
-
 	lockPackages, err := hcl2nix.ResolvePackages(ctx, sc, conf.Packages, pkgType)
 	if err != nil {
 		return err

--- a/pkg/hcl2nix/config.go
+++ b/pkg/hcl2nix/config.go
@@ -79,19 +79,17 @@ func ModifyConfig(oldName string, artifact OCIArtifact, config *Config) error {
 		}
 	}
 
-	if !updated {
-		config.OCIArtifact = append(config.OCIArtifact, artifact)
-	}
+	if updated {
+		var buf bytes.Buffer
+		err := WriteConfig(*config, &buf)
+		if err != nil {
+			return err
+		}
 
-	var buf bytes.Buffer
-	err := WriteConfig(*config, &buf)
-	if err != nil {
-		return err
-	}
-
-	err = os.WriteFile("bsf.hcl", buf.Bytes(), 0644)
-	if err != nil {
-		return err
+		err = os.WriteFile("bsf.hcl", buf.Bytes(), 0644)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/hcl2nix/config.go
+++ b/pkg/hcl2nix/config.go
@@ -1,7 +1,10 @@
 package hcl2nix
 
 import (
+	"bytes"
+	"fmt"
 	"io"
+	"os"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -39,6 +42,21 @@ type Packages struct {
 	Runtime     []string `hcl:"runtime"`
 }
 
+// ReadHclFile reads an HCL file
+func ReadHclFile(fileName string) (*Config, error) {
+	data, err := os.ReadFile(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("error: %s", err.Error())
+	}
+
+	var dstErr bytes.Buffer
+	conf, err := ReadConfig(data, &dstErr)
+	if err != nil {
+		return nil, fmt.Errorf(dstErr.String())
+	}
+	return conf, nil
+}
+
 // WriteConfig writes packages to writer
 func WriteConfig(config Config, wr io.Writer) error {
 	f := hclwrite.NewEmptyFile()
@@ -47,6 +65,35 @@ func WriteConfig(config Config, wr io.Writer) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+// ModifyConfig modifes the config
+func ModifyConfig(oldName string, artifact OCIArtifact, config *Config) error {
+	updated := false
+	for i, existingArtifact := range config.OCIArtifact {
+		if existingArtifact.Name == oldName {
+			config.OCIArtifact[i] = artifact
+			updated = true
+			break
+		}
+	}
+
+	if !updated {
+		config.OCIArtifact = append(config.OCIArtifact, artifact)
+	}
+
+	var buf bytes.Buffer
+	err := WriteConfig(*config, &buf)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile("bsf.hcl", buf.Bytes(), 0644)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
When a `--tag` flag will be passed with OCI cmd, bsf will rewrite the `bsf.hcl` file with the new tag for the artifact generation.