### PR TITLE
feat: add support for bsf update for non-semver packages

### DIFF
--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -28,7 +28,7 @@ var UpdateCmd = &cobra.Command{
 	Long: `Updates can be done for development and runtime dependencies based on constraints. Following constraints are supported:
 		~ : latest patch version
 		^ : latest minor version
-
+		# : latest calver version
 		Currently, only packages following semver versioning are supported.
 
 		`,

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -28,7 +28,7 @@ var UpdateCmd = &cobra.Command{
 	Long: `Updates can be done for development and runtime dependencies based on constraints. Following constraints are supported:
 		~ : latest patch version
 		^ : latest minor version
-		# : latest calver version
+		# : date based updates
 		Currently, only packages following semver versioning are supported.
 
 		`,

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -123,6 +123,12 @@ func parsePackagesForUpdates(versionMap map[string]*buildsafev1.FetchPackagesRes
 		updateType := update.ParseUpdateType(k)
 
 		switch updateType {
+		case update.UpdateTypeDate:
+			newVer := update.GetDateBasedVersion(v, version)
+			if newVer != "" {
+				newVersions = append(newVersions, fmt.Sprintf("%s@#%s", name, newVer))
+			}
+
 		case update.UpdateTypePatch:
 			newVer := update.GetLatestPatchVersion(v, version)
 			if newVer != "" {

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -124,7 +124,7 @@ func parsePackagesForUpdates(versionMap map[string]*buildsafev1.FetchPackagesRes
 
 		switch updateType {
 		case update.UpdateTypeDate:
-			newVer := update.GetDateBasedVersion(v, version)
+			newVer := update.GetDateBasedVersion(v)
 			if newVer != "" {
 				newVersions = append(newVersions, fmt.Sprintf("%s@#%s", name, newVer))
 			}

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -28,7 +28,7 @@ var UpdateCmd = &cobra.Command{
 	Long: `Updates can be done for development and runtime dependencies based on constraints. Following constraints are supported:
 		~ : latest patch version
 		^ : latest minor version
-		# : date based updates
+		# : date based updates. Useful, when a package doesn't follow semver and we want to update to the latest published version
 		Currently, only packages following semver versioning are supported.
 
 		`,

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -48,7 +48,7 @@ func ParsePackage(pkg string) (name, version string) {
 }
 
 // GetDateBasedVersion returns the latest date version for the given version.
-func GetDateBasedVersion(v *buildsafev1.FetchPackagesResponse, version string) string {
+func GetDateBasedVersion(v *buildsafev1.FetchPackagesResponse) string {
 	if v == nil || len(v.Packages) == 0 {
 		return ""
 	}

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -49,11 +49,11 @@ func ParsePackage(pkg string) (name, version string) {
 
 // GetDateBasedVersion returns the latest date version for the given version.
 func GetDateBasedVersion(v *buildsafev1.FetchPackagesResponse, version string) string {
-	if v == nil {
+	if v == nil || len(v.Packages) == 0 {
 		return ""
 	}
 
-	// sorting epochs
+	// sorting EpochSeconds
 	sort.Slice(v.Packages, func(i, j int) bool {
 		return v.Packages[i].EpochSeconds > v.Packages[j].EpochSeconds
 	})

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -1,6 +1,7 @@
 package update
 
 import (
+	"sort"
 	"strings"
 
 	buildsafev1 "github.com/buildsafedev/bsf-apis/go/buildsafe/v1"
@@ -52,20 +53,12 @@ func GetDateBasedVersion(v *buildsafev1.FetchPackagesResponse, version string) s
 		return ""
 	}
 
-	var latestVersion string
-	var latestDate string
+	// sorting epochs
+	sort.Slice(v.Packages, func(i, j int) bool {
+		return v.Packages[i].EpochSeconds > v.Packages[j].EpochSeconds
+	})
 
-	for _, pkg := range v.Packages {
-		if strings.HasPrefix(pkg.Version, version[:4]) {
-			datePart := strings.TrimPrefix(pkg.Version, version[:4]+".")
-			if datePart > latestDate {
-				latestDate = datePart
-				latestVersion = pkg.Version
-			}
-		}
-	}
-
-	return latestVersion
+	return v.Packages[0].Version
 }
 
 // GetLatestPatchVersion returns the latest patch version for the given version.

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -48,7 +48,7 @@ func TestGetDateBasedVersion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := GetDateBasedVersion(test.input, "")
+			result := GetDateBasedVersion(test.input)
 			if result != test.expected {
 				t.Errorf("expected %v, got %v", test.expected, result)
 			}

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -6,6 +6,79 @@ import (
 	buildsafev1 "github.com/buildsafedev/bsf-apis/go/buildsafe/v1"
 )
 
+func TestGetDateBasedVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *buildsafev1.FetchPackagesResponse
+		version  string
+		want     string
+	}{
+		{
+			name: "Test Case 1",
+			response: &buildsafev1.FetchPackagesResponse{
+				Packages: []*buildsafev1.Package{
+					{Version: "2023.06.15"},
+					{Version: "2023.07.01"},
+					{Version: "2023.07.10"},
+				},
+			},
+			version: "2023",
+			want:    "2023.07.10",
+		},
+		{
+			name: "Test Case 2",
+			response: &buildsafev1.FetchPackagesResponse{
+				Packages: []*buildsafev1.Package{
+					{Version: "2022.12.25"},
+					{Version: "2023.01.01"},
+					{Version: "2023.01.02"},
+				},
+			},
+			version: "2023",
+			want:    "2023.01.02",
+		},
+		{
+			name:     "Test Case 3",
+			response: nil,
+			version:  "2023",
+			want:     "",
+		},
+		{
+			name: "Test Case 4",
+			response: &buildsafev1.FetchPackagesResponse{
+				Packages: []*buildsafev1.Package{
+					{Version: "2023.01.01"},
+					{Version: "2023.01.02"},
+					{Version: "2023.01.03"},
+					{Version: "2022.12.31"},
+				},
+			},
+			version: "2023",
+			want:    "2023.01.03",
+		},
+		{
+			name: "Test Case 5",
+			response: &buildsafev1.FetchPackagesResponse{
+				Packages: []*buildsafev1.Package{
+					{Version: "2023.02.01"},
+					{Version: "2023.02.02"},
+					{Version: "2023.02.03"},
+				},
+			},
+			version: "2023.02",
+			want:    "2023.02.03",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetDateBasedVersion(tt.response, tt.version); got != tt.want {
+				t.Errorf("GetDateBasedVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetLatestPatchVersion(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -9,71 +9,48 @@ import (
 func TestGetDateBasedVersion(t *testing.T) {
 	tests := []struct {
 		name     string
-		response *buildsafev1.FetchPackagesResponse
-		version  string
-		want     string
+		input    *buildsafev1.FetchPackagesResponse
+		expected string
 	}{
 		{
-			name: "Test Case 1",
-			response: &buildsafev1.FetchPackagesResponse{
-				Packages: []*buildsafev1.Package{
-					{Version: "2023.06.15"},
-					{Version: "2023.07.01"},
-					{Version: "2023.07.10"},
-				},
-			},
-			version: "2023",
-			want:    "2023.07.10",
+			name:     "Test Case 1",
+			input:    nil,
+			expected: "",
 		},
 		{
 			name: "Test Case 2",
-			response: &buildsafev1.FetchPackagesResponse{
-				Packages: []*buildsafev1.Package{
-					{Version: "2022.12.25"},
-					{Version: "2023.01.01"},
-					{Version: "2023.01.02"},
-				},
+			input: &buildsafev1.FetchPackagesResponse{
+				Packages: []*buildsafev1.Package{},
 			},
-			version: "2023",
-			want:    "2023.01.02",
+			expected: "",
 		},
 		{
-			name:     "Test Case 3",
-			response: nil,
-			version:  "2023",
-			want:     "",
+			name: "Test Case 3",
+			input: &buildsafev1.FetchPackagesResponse{
+				Packages: []*buildsafev1.Package{
+					{Version: "1.0.0", EpochSeconds: 100},
+				},
+			},
+			expected: "1.0.0",
 		},
 		{
 			name: "Test Case 4",
-			response: &buildsafev1.FetchPackagesResponse{
+			input: &buildsafev1.FetchPackagesResponse{
 				Packages: []*buildsafev1.Package{
-					{Version: "2023.01.01"},
-					{Version: "2023.01.02"},
-					{Version: "2023.01.03"},
-					{Version: "2022.12.31"},
+					{Version: "1.0.0", EpochSeconds: 100},
+					{Version: "2.0.0", EpochSeconds: 200},
+					{Version: "1.5.0", EpochSeconds: 150},
 				},
 			},
-			version: "2023",
-			want:    "2023.01.03",
-		},
-		{
-			name: "Test Case 5",
-			response: &buildsafev1.FetchPackagesResponse{
-				Packages: []*buildsafev1.Package{
-					{Version: "2023.02.01"},
-					{Version: "2023.02.02"},
-					{Version: "2023.02.03"},
-				},
-			},
-			version: "2023.02",
-			want:    "2023.02.03",
+			expected: "2.0.0",
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetDateBasedVersion(tt.response, tt.version); got != tt.want {
-				t.Errorf("GetDateBasedVersion() = %v, want %v", got, tt.want)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := GetDateBasedVersion(test.input, "")
+			if result != test.expected {
+				t.Errorf("expected %v, got %v", test.expected, result)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #29 
Fixes #29 

## Description
This PR adds supports for `non-semver` packages in `bsf update` command.