### PR TITLE
regenerate lock/flake files post search

### DIFF
--- a/bsf.hcl
+++ b/bsf.hcl
@@ -1,6 +1,6 @@
 
 packages {
-  development = ["go@1.21.6", "gotools@0.16.1", "delve@1.22.0", "go-task@~3.37.2"]
+  development = ["go@1.21.6", "gotools@0.16.1", "delve@1.22.0", "go-task@~3.37.2", "golangci-lint@~1.59.0"]
   runtime     = ["cacert@3.95"]
 }
 
@@ -12,8 +12,8 @@ gomodule {
   doCheck = false
 }
 
-
 githubRelease "bsf" {
   owner = "buildsafedev"
   repo  = "bsf"
+  dir   = ""
 }

--- a/bsf.lock
+++ b/bsf.lock
@@ -5,14 +5,14 @@
   "packages": [
     {
       "package": {
-        "name": "delve",
-        "revision": "a731d0cb71c58f56895f71a5b02eda2962a46746",
-        "version": "1.22.0",
-        "description": "debugger for the Go programming language",
-        "homepage": "https://github.com/go-delve/delve",
+        "name": "golangci-lint",
+        "revision": "7445ccd775d8b892fc56448d17345443a05f7fb4",
+        "version": "1.59.0",
+        "description": "Fast linters Runner for Go",
+        "homepage": "https://golangci-lint.run/",
         "free": true,
-        "spdx_id": "MIT",
-        "epoch_seconds": 1705066566,
+        "spdx_id": "GPL-3.0-or-later",
+        "epoch_seconds": 1716993062,
         "platforms": [
           "x86_64-darwin",
           "i686-darwin",
@@ -38,48 +38,11 @@
           "riscv64-linux",
           "s390-linux",
           "s390x-linux",
-          "x86_64-linux"
-        ]
-      },
-      "runtime": false
-    },
-    {
-      "package": {
-        "name": "gotools",
-        "revision": "ac5c1886fd9fe49748d7ab80accc4c847481df14",
-        "version": "0.16.1",
-        "description": "Additional tools for Go development",
-        "homepage": "https://go.googlesource.com/tools",
-        "free": true,
-        "spdx_id": "BSD-3-Clause",
-        "epoch_seconds": 1699289668,
-        "platforms": [
-          "x86_64-darwin",
-          "i686-darwin",
-          "aarch64-darwin",
-          "armv7a-darwin",
-          "aarch64-linux",
-          "armv5tel-linux",
-          "armv6l-linux",
-          "armv7a-linux",
-          "armv7l-linux",
-          "i686-linux",
-          "loongarch64-linux",
-          "m68k-linux",
-          "microblaze-linux",
-          "microblazeel-linux",
-          "mips-linux",
-          "mips64-linux",
-          "mips64el-linux",
-          "mipsel-linux",
-          "powerpc64-linux",
-          "powerpc64le-linux",
-          "riscv32-linux",
-          "riscv64-linux",
-          "s390-linux",
-          "s390x-linux",
-          "x86_64-linux"
-        ]
+          "x86_64-linux",
+          "wasm64-wasi",
+          "wasm32-wasi"
+        ],
+        "attr_name": "golangci-lint"
       },
       "runtime": false
     },
@@ -123,6 +86,46 @@
           "wasm32-wasi"
         ],
         "attr_name": "go-task"
+      },
+      "runtime": false
+    },
+    {
+      "package": {
+        "name": "delve",
+        "revision": "a731d0cb71c58f56895f71a5b02eda2962a46746",
+        "version": "1.22.0",
+        "description": "debugger for the Go programming language",
+        "homepage": "https://github.com/go-delve/delve",
+        "free": true,
+        "spdx_id": "MIT",
+        "epoch_seconds": 1705066566,
+        "platforms": [
+          "x86_64-darwin",
+          "i686-darwin",
+          "aarch64-darwin",
+          "armv7a-darwin",
+          "aarch64-linux",
+          "armv5tel-linux",
+          "armv6l-linux",
+          "armv7a-linux",
+          "armv7l-linux",
+          "i686-linux",
+          "loongarch64-linux",
+          "m68k-linux",
+          "microblaze-linux",
+          "microblazeel-linux",
+          "mips-linux",
+          "mips64-linux",
+          "mips64el-linux",
+          "mipsel-linux",
+          "powerpc64-linux",
+          "powerpc64le-linux",
+          "riscv32-linux",
+          "riscv64-linux",
+          "s390-linux",
+          "s390x-linux",
+          "x86_64-linux"
+        ]
       },
       "runtime": false
     },
@@ -255,6 +258,46 @@
         ]
       },
       "runtime": true
+    },
+    {
+      "package": {
+        "name": "gotools",
+        "revision": "ac5c1886fd9fe49748d7ab80accc4c847481df14",
+        "version": "0.16.1",
+        "description": "Additional tools for Go development",
+        "homepage": "https://go.googlesource.com/tools",
+        "free": true,
+        "spdx_id": "BSD-3-Clause",
+        "epoch_seconds": 1699289668,
+        "platforms": [
+          "x86_64-darwin",
+          "i686-darwin",
+          "aarch64-darwin",
+          "armv7a-darwin",
+          "aarch64-linux",
+          "armv5tel-linux",
+          "armv6l-linux",
+          "armv7a-linux",
+          "armv7l-linux",
+          "i686-linux",
+          "loongarch64-linux",
+          "m68k-linux",
+          "microblaze-linux",
+          "microblazeel-linux",
+          "mips-linux",
+          "mips64-linux",
+          "mips64el-linux",
+          "mipsel-linux",
+          "powerpc64-linux",
+          "powerpc64le-linux",
+          "riscv32-linux",
+          "riscv64-linux",
+          "s390-linux",
+          "s390x-linux",
+          "x86_64-linux"
+        ]
+      },
+      "runtime": false
     }
   ]
 }

--- a/bsf/flake.nix
+++ b/bsf/flake.nix
@@ -78,6 +78,7 @@
 			nixpkgs-a731d0cb71c58f56895f71a5b02eda2962a46746-pkgs.delve  
 			nixpkgs-a731d0cb71c58f56895f71a5b02eda2962a46746-pkgs.go  
 			nixpkgs-7445ccd775d8b892fc56448d17345443a05f7fb4-pkgs.go-task  
+			nixpkgs-7445ccd775d8b892fc56448d17345443a05f7fb4-pkgs.golangci-lint  
 			nixpkgs-ac5c1886fd9fe49748d7ab80accc4c847481df14-pkgs.gotools  
 			
 		  ];
@@ -109,6 +110,7 @@
 			nixpkgs-a731d0cb71c58f56895f71a5b02eda2962a46746-pkgs.delve  
 			nixpkgs-a731d0cb71c58f56895f71a5b02eda2962a46746-pkgs.go  
 			nixpkgs-7445ccd775d8b892fc56448d17345443a05f7fb4-pkgs.go-task  
+			nixpkgs-7445ccd775d8b892fc56448d17345443a05f7fb4-pkgs.golangci-lint  
 			nixpkgs-ac5c1886fd9fe49748d7ab80accc4c847481df14-pkgs.gotools  
 			
 		   ];

--- a/cmd/search/constraints.go
+++ b/cmd/search/constraints.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/buildsafedev/bsf/cmd/styles"
+	"github.com/buildsafedev/bsf/pkg/generate"
 	"github.com/buildsafedev/bsf/pkg/hcl2nix"
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
@@ -139,6 +140,12 @@ func (m *versionConstraintsModel) updateVersionConstraint() (tea.Model, tea.Cmd)
 	err = hcl2nix.AddPackages(data, newConfFromSelectedPackages(m.name, m.version, m.selectedConstraints, m.env), fh.ModFile)
 	if err != nil {
 		m.errorMsg = fmt.Sprintf(errorStyle.Render("Error updating bsf.hcl: %s", err.Error()))
+		return m, tea.Quit
+	}
+
+	err = generate.Generate(fh, sc)
+	if err != nil {
+		m.errorMsg = fmt.Sprintf(errorStyle.Render("Error regenerating nix files: %s", err.Error()))
 		return m, tea.Quit
 	}
 


### PR DESCRIPTION
* regenerates lock/flake files post search when package is added. 
* Adds golangci-lint

Functionally, all the bsf commands should still work but a little detail that users might find weird. Thanks to @hanshal101 for reporting on Discord. 