### PR TITLE
fix: dev pkgs bug in base img

### DIFF
--- a/cmd/init/config.go
+++ b/cmd/init/config.go
@@ -48,7 +48,6 @@ func generateEmptyConf() hcl2nix.Config {
 				EnvVars:    []string{},
 				ExposedPorts: []string{},
 				ImportConfigs: []string{},
-				DevDeps: false,
 			},
 		},
 	}
@@ -92,7 +91,6 @@ func genRustCargoConf() (hcl2nix.Config, error) {
 				EnvVars:    []string{},
 				ExposedPorts: []string{},
 				ImportConfigs: []string{},
-				DevDeps: false,
 			},
 		},
 	}, nil
@@ -122,7 +120,6 @@ func genPythonPoetryConf() hcl2nix.Config {
 				EnvVars:    []string{},
 				ExposedPorts: []string{},
 				ImportConfigs: []string{},
-				DevDeps: false,
 			},
 		},
 	}
@@ -157,7 +154,6 @@ func genGoModuleConf(pd *langdetect.ProjectDetails) hcl2nix.Config {
 				EnvVars:    []string{},
 				ExposedPorts: []string{},
 				ImportConfigs: []string{},
-				DevDeps: false,
 			},
 		},
 	}
@@ -197,7 +193,6 @@ func genJsNpmConf() (hcl2nix.Config, error) {
 				EnvVars:    []string{},
 				ExposedPorts: []string{},
 				ImportConfigs: []string{},
-				DevDeps: false,
 			},
 		},
 	}, nil

--- a/cmd/oci/oci.go
+++ b/cmd/oci/oci.go
@@ -321,13 +321,13 @@ func genOCIAttrName(env, platform string, artifact hcl2nix.OCIArtifact) string {
 	base := fmt.Sprintf("bsf/.#ociImages.%s.ociImage_%s_", arch, env)
 
 	if env == "pkgs" {
-		if devDeps || artifact.DevDeps {
+		if devDeps {
 			return base + "dev-as-dir"
 		}
 		return base + "runtime-as-dir"
 	}
 
-	if devDeps || artifact.DevDeps {
+	if devDeps {
 		return base + "app_with_dev-as-dir"
 	}
 	return base + "app-as-dir"

--- a/pkg/builddocker/build.go
+++ b/pkg/builddocker/build.go
@@ -20,7 +20,6 @@ type dockerfileCfg struct {
 	Cmd        []string
 	Entrypoint []string
 	EnvVars    map[string]string
-	DevDeps    bool
 	Config     string
 }
 
@@ -132,7 +131,6 @@ func convertExportCfgToDockerfileCfg(env hcl2nix.OCIArtifact, platform string) d
 		Cmd:        env.Cmd,
 		Entrypoint: env.Entrypoint,
 		EnvVars:    envVarsMap,
-		DevDeps:    env.DevDeps,
 	}
 }
 

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -25,8 +25,7 @@ func Generate(fh *hcl2nix.FileHandlers, sc buildsafev1.SearchServiceClient) erro
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 	defer cancel()
 
-	pkgType := getPkgType(conf)
-	lockPackages, err := hcl2nix.ResolvePackages(ctx, sc, conf.Packages, pkgType)
+	lockPackages, err := hcl2nix.ResolvePackages(ctx, sc, conf.Packages)
 	if err != nil {
 		return err
 	}
@@ -57,18 +56,6 @@ func Generate(fh *hcl2nix.FileHandlers, sc buildsafev1.SearchServiceClient) erro
 	}
 
 	return nil
-}
-
-func getPkgType(conf *hcl2nix.Config) string {
-	for _, conf := range conf.OCIArtifact {
-		if conf.Artifact == "pkgs" {
-			if conf.DevDeps {
-				return "dev"
-			}
-			return "runtime"
-		}
-	}
-	return "all"
 }
 
 func findLang(conf *hcl2nix.Config) langdetect.ProjectType {

--- a/pkg/hcl2nix/export.go
+++ b/pkg/hcl2nix/export.go
@@ -20,9 +20,6 @@ type OCIArtifact struct {
 	ExposedPorts []string `hcl:"exposedPorts,optional"`
 	// Names of configs to import
 	ImportConfigs []string `hcl:"importConfigs,optional"`
-	// DevDeps defines if development dependencies should be present in the image. By default, it is false.
-	DevDeps bool `hcl:"devDeps,optional"`
-
 }
 
 // Validate validates ExportConfig

--- a/pkg/nix/template/oci.go
+++ b/pkg/nix/template/oci.go
@@ -16,7 +16,6 @@ type OCIArtifact struct {
 	EnvVars       []string
 	ImportConfigs []string
 	ExposedPorts  []string
-	DevDeps       bool
 	Base          bool
 }
 
@@ -138,6 +137,7 @@ const (
 			layers = [
 				(nix2containerPkgs.nix2container.buildLayer { 
 					copyToRoot = [
+						inputs.self.runtimeEnvs.${system}.runtime
 						{{range $config := $artifact.ImportConfigs}}
 						inputs.self.configs.${system}.config_{{ . }} {{end}}
 						inputs.self.devEnvs.${system}.development
@@ -175,7 +175,6 @@ func hclOCIToOCIArtifact(ociArtifacts []hcl2nix.OCIArtifact) []OCIArtifact {
 			EnvVars:       ociArtifact.EnvVars,
 			ImportConfigs: ociArtifact.ImportConfigs,
 			ExposedPorts:  ociArtifact.ExposedPorts,
-			DevDeps:       ociArtifact.DevDeps,
 		}
 		if ociArtifact.Artifact == "pkgs" {
 			converted[i].Base = true

--- a/pkg/nix/template/oci_test.go
+++ b/pkg/nix/template/oci_test.go
@@ -14,7 +14,6 @@ func TestGenerateOCIAttr(t *testing.T) {
 			EnvVars:       []string{"VAR1=value1", "VAR2=value2"},
 			ExposedPorts:  []string{"8080", "8081"},
 			ImportConfigs: []string{"config1", "config2"},
-			DevDeps:       true,
 		},
 		{
 			Artifact:     "Test2",


### PR DESCRIPTION
This PR fixes a bug that we saw while creating base images:

* If a user had a package in dev block, but it was not there in the runtime block, it was not being shown in the `flake.nix`, i.e. the flake generation was being wrong for development packages.