### PR TITLE
fix: fix all lint errors shown in golangci-lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,3 @@ jobs:
 
       - name: Run GolangCI-Lint
         run: task lint
-        continue-on-error: true

--- a/cmd/direnv/direnv.go
+++ b/cmd/direnv/direnv.go
@@ -89,6 +89,9 @@ func fetchGitignore() error {
 		if !strings.Contains(string(read), ".envrc") {
 
 			file, err := os.OpenFile(".gitignore", os.O_APPEND|os.O_WRONLY, 0644)
+			if err != nil {
+				return err
+			}
 			_, err = file.WriteString("\n.envrc")
 			if err != nil {
 				return err

--- a/cmd/init/model.go
+++ b/cmd/init/model.go
@@ -21,9 +21,9 @@ var (
 	textStyle    = styles.TextStyle.Render
 	sucessStyle  = styles.SucessStyle.Render
 	spinnerStyle = styles.SpinnerStyle
-	helpStyle    = styles.HelpStyle.Render
-	errorStyle   = styles.ErrorStyle.Render
-	stages       = 4
+	// helpStyle    = styles.HelpStyle.Render
+	errorStyle = styles.ErrorStyle.Render
+	stages     = 4
 )
 
 type model struct {

--- a/cmd/nixgenerate/model.go
+++ b/cmd/nixgenerate/model.go
@@ -18,9 +18,9 @@ var (
 	textStyle    = styles.TextStyle.Render
 	sucessStyle  = styles.SucessStyle.Render
 	spinnerStyle = styles.SpinnerStyle
-	helpStyle    = styles.HelpStyle.Render
-	errorStyle   = styles.ErrorStyle.Render
-	stages       = 2
+	// helpStyle    = styles.HelpStyle.Render
+	errorStyle = styles.ErrorStyle.Render
+	stages     = 2
 )
 
 type model struct {

--- a/cmd/precheck/precheck.go
+++ b/cmd/precheck/precheck.go
@@ -29,11 +29,7 @@ var PreCheckCmd = &cobra.Command{
 func checkVersionGreater(currentVer string, nixversion string) bool {
 	val := semver.Compare(currentVer, nixversion)
 
-	if val < 0 {
-		return false
-	}
-
-	return true
+	return val >= 0
 }
 
 // ValidateNixVersion checks if the current nix version is it compatible with bsf

--- a/cmd/search/constraints.go
+++ b/cmd/search/constraints.go
@@ -116,7 +116,7 @@ func (m *versionConstraintsModel) updateVersionConstraint() (tea.Model, tea.Cmd)
 
 	data, err := os.ReadFile("bsf.hcl")
 	if err != nil {
-		m.errorMsg = fmt.Sprintf(errorStyle.Render("Error reading bsf.hcl: %s", err.Error()))
+		m.errorMsg = errorStyle.Render(fmt.Sprintf("Error reading bsf.hcl: %s", err.Error()))
 		return m, tea.Quit
 	}
 
@@ -133,19 +133,19 @@ func (m *versionConstraintsModel) updateVersionConstraint() (tea.Model, tea.Cmd)
 	// changing file handler to allow writes
 	fh.ModFile, err = os.Create("bsf.hcl")
 	if err != nil {
-		m.errorMsg = fmt.Sprintf(errorStyle.Render("Error creating bsf.hcl: %s", err.Error()))
+		m.errorMsg = errorStyle.Render(fmt.Sprintf("Error creating bsf.hcl: %s", err.Error()))
 		return m, tea.Quit
 	}
 
 	err = hcl2nix.AddPackages(data, newConfFromSelectedPackages(m.name, m.version, m.selectedConstraints, m.env), fh.ModFile)
 	if err != nil {
-		m.errorMsg = fmt.Sprintf(errorStyle.Render("Error updating bsf.hcl: %s", err.Error()))
+		m.errorMsg = errorStyle.Render(fmt.Sprintf("Error updating bsf.hcl: %s", err.Error()))
 		return m, tea.Quit
 	}
 
 	err = generate.Generate(fh, sc)
 	if err != nil {
-		m.errorMsg = fmt.Sprintf(errorStyle.Render("Error regenerating nix files: %s", err.Error()))
+		m.errorMsg = errorStyle.Render(fmt.Sprintf("Error regenerating bsf.hcl: %s", err.Error()))
 		return m, tea.Quit
 	}
 

--- a/cmd/search/model.go
+++ b/cmd/search/model.go
@@ -35,10 +35,6 @@ func convLPR2Items(packages *buildsafev1.ListPackagesResponse) []list.Item {
 	return items
 }
 
-// type (
-// 	errMsg struct{ error }
-// )
-
 type mode int
 
 const (

--- a/cmd/search/model.go
+++ b/cmd/search/model.go
@@ -35,9 +35,9 @@ func convLPR2Items(packages *buildsafev1.ListPackagesResponse) []list.Item {
 	return items
 }
 
-type (
-	errMsg struct{ error }
-)
+// type (
+// 	errMsg struct{ error }
+// )
 
 type mode int
 

--- a/cmd/search/option.go
+++ b/cmd/search/option.go
@@ -88,7 +88,7 @@ func (m packageOptionModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if semver.IsValid("v" + m.version) {
 				v := initVersionConstraints(m.name, m.version, m.selected, m)
 				p := tea.NewProgram(v, tea.WithAltScreen())
-				if err := p.Start(); err != nil {
+				if _, err := p.Run(); err != nil {
 					m.errorMsg = fmt.Sprintf("Error starting version constraints model: %s", err.Error())
 				}
 			} else {

--- a/pkg/builddocker/build.go
+++ b/pkg/builddocker/build.go
@@ -5,12 +5,9 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"math/rand"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/buildsafedev/bsf/pkg/hcl2nix"
 )
@@ -75,47 +72,47 @@ func readDockerFile(file *os.File) ([]string, error) {
 	return lines, nil
 }
 
-	func editDockerfile(lines []string, dev bool, tag string) ([]string, error) {
-		var searchTag string
-		if dev {
-			searchTag = "bsfimage:dev"
-		} else {
-			searchTag = "bsfimage:runtime"
-		}
-
-		var selectedFrom string
-		var selectedIndex int
-		for i, line := range lines {
-			if strings.Contains(line, searchTag) {
-				selectedFrom = line
-				selectedIndex = i
-				break
-			}
-		}
-
-		if selectedFrom == "" {
-			return nil, fmt.Errorf("no FROM command found with tag %s", searchTag)
-		}
-
-		fromParts := strings.Fields(selectedFrom)
-		if len(fromParts) < 2 {
-			return nil, fmt.Errorf("invalid FROM command format")
-		}
-
-		var newFrom string
-		if strings.Contains(fromParts[1], ":") {
-			imageParts := strings.Split(fromParts[1], ":")
-			newFrom = fmt.Sprintf("FROM %s:%s", imageParts[0], tag)
-		} else {
-			newFrom = fmt.Sprintf("FROM %s:%s", fromParts[1], tag)
-		}
-		for _, part := range fromParts[2:] {
-			newFrom = fmt.Sprintf("%s %s", newFrom, part)
-		}
-
-		lines[selectedIndex] = newFrom
-		return lines, nil
+func editDockerfile(lines []string, dev bool, tag string) ([]string, error) {
+	var searchTag string
+	if dev {
+		searchTag = "bsfimage:dev"
+	} else {
+		searchTag = "bsfimage:runtime"
 	}
+
+	var selectedFrom string
+	var selectedIndex int
+	for i, line := range lines {
+		if strings.Contains(line, searchTag) {
+			selectedFrom = line
+			selectedIndex = i
+			break
+		}
+	}
+
+	if selectedFrom == "" {
+		return nil, fmt.Errorf("no FROM command found with tag %s", searchTag)
+	}
+
+	fromParts := strings.Fields(selectedFrom)
+	if len(fromParts) < 2 {
+		return nil, fmt.Errorf("invalid FROM command format")
+	}
+
+	var newFrom string
+	if strings.Contains(fromParts[1], ":") {
+		imageParts := strings.Split(fromParts[1], ":")
+		newFrom = fmt.Sprintf("FROM %s:%s", imageParts[0], tag)
+	} else {
+		newFrom = fmt.Sprintf("FROM %s:%s", fromParts[1], tag)
+	}
+	for _, part := range fromParts[2:] {
+		newFrom = fmt.Sprintf("%s %s", newFrom, part)
+	}
+
+	lines[selectedIndex] = newFrom
+	return lines, nil
+}
 
 func convertExportCfgToDockerfileCfg(env hcl2nix.OCIArtifact, platform string) dockerfileCfg {
 	switch platform {
@@ -135,31 +132,31 @@ func convertExportCfgToDockerfileCfg(env hcl2nix.OCIArtifact, platform string) d
 }
 
 // generateRandomFilename generates a random filename
-func generateRandomFilename() string {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	letterRunes := []rune("abcdefghijklmnopqrstuvwxyz")
-	b := make([]rune, 10)
-	for i := range b {
-		b[i] = letterRunes[r.Intn(len(letterRunes))]
-	}
-	return string(b)
-}
+// func generateRandomFilename() string {
+// 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+// 	letterRunes := []rune("abcdefghijklmnopqrstuvwxyz")
+// 	b := make([]rune, 10)
+// 	for i := range b {
+// 		b[i] = letterRunes[r.Intn(len(letterRunes))]
+// 	}
+// 	return string(b)
+// }
 
-func createTempDir() (string, error) {
-	tmpDir := os.TempDir()
-	bsfDir := filepath.Join(tmpDir, "bsf")
+// func createTempDir() (string, error) {
+// 	tmpDir := os.TempDir()
+// 	bsfDir := filepath.Join(tmpDir, "bsf")
 
-	if _, err := os.Stat(bsfDir); os.IsNotExist(err) {
-		err := os.Mkdir(bsfDir, 0755)
-		if err != nil {
-			return "", err
-		}
-	} else if err != nil {
-		return "", err
-	}
+// 	if _, err := os.Stat(bsfDir); os.IsNotExist(err) {
+// 		err := os.Mkdir(bsfDir, 0755)
+// 		if err != nil {
+// 			return "", err
+// 		}
+// 	} else if err != nil {
+// 		return "", err
+// 	}
 
-	return bsfDir, nil
-}
+// 	return bsfDir, nil
+// }
 
 func convertEnvsToMap(envs []string) map[string]string {
 	envMap := make(map[string]string)

--- a/pkg/builddocker/build.go
+++ b/pkg/builddocker/build.go
@@ -131,17 +131,6 @@ func convertExportCfgToDockerfileCfg(env hcl2nix.OCIArtifact, platform string) d
 	}
 }
 
-// generateRandomFilename generates a random filename
-// func generateRandomFilename() string {
-// 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-// 	letterRunes := []rune("abcdefghijklmnopqrstuvwxyz")
-// 	b := make([]rune, 10)
-// 	for i := range b {
-// 		b[i] = letterRunes[r.Intn(len(letterRunes))]
-// 	}
-// 	return string(b)
-// }
-
 // func createTempDir() (string, error) {
 // 	tmpDir := os.TempDir()
 // 	bsfDir := filepath.Join(tmpDir, "bsf")

--- a/pkg/builddocker/build.go
+++ b/pkg/builddocker/build.go
@@ -131,22 +131,6 @@ func convertExportCfgToDockerfileCfg(env hcl2nix.OCIArtifact, platform string) d
 	}
 }
 
-// func createTempDir() (string, error) {
-// 	tmpDir := os.TempDir()
-// 	bsfDir := filepath.Join(tmpDir, "bsf")
-
-// 	if _, err := os.Stat(bsfDir); os.IsNotExist(err) {
-// 		err := os.Mkdir(bsfDir, 0755)
-// 		if err != nil {
-// 			return "", err
-// 		}
-// 	} else if err != nil {
-// 		return "", err
-// 	}
-
-// 	return bsfDir, nil
-// }
-
 func convertEnvsToMap(envs []string) map[string]string {
 	envMap := make(map[string]string)
 

--- a/pkg/clients/search/search.go
+++ b/pkg/clients/search/search.go
@@ -22,7 +22,7 @@ func NewClientWithAddr(addr string, tlsSkip bool) (buildsafev1.SearchServiceClie
 	} else {
 		creds = insecure.NewCredentials()
 	}
-	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(creds))
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}
@@ -51,10 +51,7 @@ func SortPackagesWithVersion(packageVersions []*buildsafev1.Package) []*buildsaf
 		packageVersions[i].Version = "v" + packageVersions[i].Version
 	}
 	sort.Slice(packageVersions, func(i, j int) bool {
-		if semver.Compare(packageVersions[i].Version, packageVersions[j].Version) > 0 {
-			return true
-		}
-		return false
+		return semver.Compare(packageVersions[i].Version, packageVersions[j].Version) > 0
 	})
 	for i := range packageVersions {
 		packageVersions[i].Version = packageVersions[i].Version[1:]

--- a/pkg/hcl2nix/config.go
+++ b/pkg/hcl2nix/config.go
@@ -106,7 +106,9 @@ func ReadConfig(src []byte, dstErr io.Writer) (*Config, error) {
 			78,
 			true,
 		)
-		wr.WriteDiagnostics(diags)
+		if err := wr.WriteDiagnostics(diags); err != nil {
+			return nil, fmt.Errorf("error writing diagnostics: %w", err)
+		}
 		return nil, diags
 	}
 
@@ -119,7 +121,9 @@ func ReadConfig(src []byte, dstErr io.Writer) (*Config, error) {
 			78,
 			true,
 		)
-		wr.WriteDiagnostics(diags)
+		if err := wr.WriteDiagnostics(diags); err != nil {
+			return nil, fmt.Errorf("error writing diagnostics: %w", err)
+		}
 		return nil, diags
 	}
 

--- a/pkg/langdetect/langdetect.go
+++ b/pkg/langdetect/langdetect.go
@@ -32,7 +32,7 @@ type ProjectDetails struct {
 	Name       string
 }
 
-var supportedLanguages = []string{string(GoModule), string(PythonPoetry), string(RustCargo)}
+// var supportedLanguages = []string{string(GoModule), string(PythonPoetry), string(RustCargo)}
 
 // FindProjectType detects the programming language/package manager of the current project.
 func FindProjectType() (ProjectType, *ProjectDetails, error) {

--- a/pkg/nix/cmd/closure.go
+++ b/pkg/nix/cmd/closure.go
@@ -137,7 +137,6 @@ func addNarHashToGraph(graph *gographviz.Graph) {
 	}
 
 	wg.Wait()
-	return
 }
 
 // GetNarHashFromPath returns the sha256 hash of the nar

--- a/pkg/provenance/provenance.go
+++ b/pkg/provenance/provenance.go
@@ -91,6 +91,7 @@ func (s *Statement) FromDerivationClosure(drvPath string, drv *derivation.Deriva
 		},
 	}
 
+	//nolint
 	s.Predicate = prov
 
 	return nil

--- a/pkg/release/githubRelease.go
+++ b/pkg/release/githubRelease.go
@@ -46,7 +46,7 @@ func (gh *GHRelease) GHReleaseCreate(params GHParams) error {
 		return err
 	}
 	if ghRelease == nil {
-		ghRelease, err = gh.createRelease(context.Background())
+		_, err = gh.createRelease(context.Background())
 		if err != nil {
 			return err
 		}

--- a/pkg/release/oci.go
+++ b/pkg/release/oci.go
@@ -124,16 +124,16 @@ func createFileDescriptors(fs *file.Store, dir string, files []string) ([]ociv1.
 	return fileDescriptors, nil
 }
 
-func ociCreateFlake(fds []ociv1.Descriptor, params OCIParams) error {
-	// temp file
-	ff, err := os.CreateTemp("/tmp", "flake.nix")
-	if err != nil {
-		return err
-	}
+// func ociCreateFlake(fds []ociv1.Descriptor, params OCIParams) error {
+// 	// temp file
+// 	ff, err := os.CreateTemp("/tmp", "flake.nix")
+// 	if err != nil {
+// 		return err
+// 	}
 
-	defer ff.Close()
+// 	defer ff.Close()
 
-	// TODO: write flake to temp file
+// 	// TODO: write flake to temp file
 
-	return nil
-}
+// 	return nil
+// }

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -2,6 +2,8 @@ package sbom
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/awalterschulze/gographviz"
@@ -122,14 +124,30 @@ func parseLockfileToSBOMNodes(document *sbom.Document, appNode *sbom.Node, lf *h
 
 		document.NodeList.AddNode(&snode)
 		if pkg.Runtime {
-			document.NodeList.RelateNodeAtID(&snode, appNode.Id, sbom.Edge_runtimeDependency)
+			if err := document.NodeList.RelateNodeAtID(
+				&snode,
+				appNode.Id,
+				sbom.Edge_runtimeDependency,
+			); err != nil {
+				fmt.Fprintf(os.Stderr, "error : %s\n", err)
+			}
 		} else {
-			document.NodeList.RelateNodeAtID(&snode, appNode.Id, sbom.Edge_devDependency)
-			document.NodeList.RelateNodeAtID(&snode, appNode.Id, sbom.Edge_devTool)
+			if err := document.NodeList.RelateNodeAtID(
+				&snode,
+				appNode.Id,
+				sbom.Edge_devDependency,
+			); err != nil {
+				fmt.Fprintf(os.Stderr, "error : %s\n", err)
+			}
+			if err := document.NodeList.RelateNodeAtID(
+				&snode,
+				appNode.Id,
+				sbom.Edge_devTool,
+			); err != nil {
+				fmt.Fprintf(os.Stderr, "error : %s\n", err)
+			}
 		}
 	}
-
-	return
 }
 
 func parseDotGraph(document *sbom.Document, appNode *sbom.Node, graph *gographviz.Graph) {
@@ -154,10 +172,14 @@ func parseDotGraph(document *sbom.Document, appNode *sbom.Node, graph *gographvi
 			},
 		}
 		document.NodeList.AddNode(&snode)
-		document.NodeList.RelateNodeAtID(&snode, appNode.Id, sbom.Edge_contains)
+		if err := document.NodeList.RelateNodeAtID(
+			&snode,
+			appNode.Id,
+			sbom.Edge_contains,
+		); err != nil {
+			fmt.Fprintf(os.Stderr, "error : %s\n", err)
+		}
 	}
-
-	return
 }
 
 // GeneratePurl returns a package url for the given name and version

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -2,8 +2,6 @@ package sbom
 
 import (
 	"encoding/json"
-	"fmt"
-	"os"
 	"time"
 
 	"github.com/awalterschulze/gographviz"
@@ -129,7 +127,7 @@ func parseLockfileToSBOMNodes(document *sbom.Document, appNode *sbom.Node, lf *h
 				appNode.Id,
 				sbom.Edge_runtimeDependency,
 			); err != nil {
-				fmt.Fprintf(os.Stderr, "error : %s\n", err)
+				continue
 			}
 		} else {
 			if err := document.NodeList.RelateNodeAtID(
@@ -137,14 +135,14 @@ func parseLockfileToSBOMNodes(document *sbom.Document, appNode *sbom.Node, lf *h
 				appNode.Id,
 				sbom.Edge_devDependency,
 			); err != nil {
-				fmt.Fprintf(os.Stderr, "error : %s\n", err)
+				continue
 			}
 			if err := document.NodeList.RelateNodeAtID(
 				&snode,
 				appNode.Id,
 				sbom.Edge_devTool,
 			); err != nil {
-				fmt.Fprintf(os.Stderr, "error : %s\n", err)
+				continue
 			}
 		}
 	}
@@ -177,7 +175,7 @@ func parseDotGraph(document *sbom.Document, appNode *sbom.Node, graph *gographvi
 			appNode.Id,
 			sbom.Edge_contains,
 		); err != nil {
-			fmt.Fprintf(os.Stderr, "error : %s\n", err)
+			continue
 		}
 	}
 }

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -109,19 +109,19 @@ func TrimVersionInfo(pkg string) (string, string) {
 	name := s[0]
 	version := s[1]
 
-	if strings.HasPrefix(version, "~") {
+	if ok := strings.HasPrefix(version, "~"); ok {
 		version = strings.TrimPrefix(version, "~")
 	}
 
-	if strings.HasPrefix(version, "^") {
+	if ok := strings.HasPrefix(version, "^"); ok {
 		version = strings.TrimPrefix(version, "^")
 	}
 
-	if strings.HasPrefix(version, "#") {
+	if ok := strings.HasPrefix(version, "#"); ok {
 		version = strings.TrimPrefix(version, "#")
 	}
 
-	if strings.HasPrefix(version, "v") {
+	if ok := strings.HasPrefix(version, "v"); ok {
 		version = strings.TrimPrefix(version, "v")
 	}
 


### PR DESCRIPTION
## Description
As discussed with @dr-housemd fixed all the linting errors shown by `golangci-lint run ./...` command.

## Note
- All the error which contains unused functions or variables are been commented out in this PR.
- Few changes were added in some conditional statements (test and review required on them) 