### PR TITLE
feat: add input prompts for the init command

### DIFF
--- a/cmd/init/config.go
+++ b/cmd/init/config.go
@@ -11,29 +11,34 @@ import (
 )
 
 func generatehcl2NixConf(pt langdetect.ProjectType, pd *langdetect.ProjectDetails) (hcl2nix.Config, error) {
+	fmt.Println("IN GENERATE HCL NIX CONFIG -------------------------------------------")
+	fmt.Println("NAME: ", pd.Name)
 	switch pt {
 	case langdetect.GoModule:
 		return genGoModuleConf(pd), nil
 	case langdetect.PythonPoetry:
-		return genPythonPoetryConf(), nil
+		return genPythonPoetryConf(pd), nil
 	case langdetect.RustCargo:
-		config, err := genRustCargoConf()
+		config, err := genRustCargoConf(pd)
 		if err != nil {
 			return hcl2nix.Config{}, err
 		}
 		return config, nil
 	case langdetect.JsNpm:
-		config, err := genJsNpmConf()
+		config, err := genJsNpmConf(pd)
 		if err != nil {
 			return hcl2nix.Config{}, err
 		}
 		return config, nil
 	default:
-		return generateEmptyConf(), nil
+		return generateEmptyConf(pd), nil
 	}
 }
 
-func generateEmptyConf() hcl2nix.Config {
+func generateEmptyConf(pd *langdetect.ProjectDetails) hcl2nix.Config {
+	if pd.Name == "" {
+		pd.Name = "expl"
+	}
 	return hcl2nix.Config{
 		Packages: hcl2nix.Packages{
 			Development: []string{""},
@@ -41,18 +46,21 @@ func generateEmptyConf() hcl2nix.Config {
 		},
 		OCIArtifact: []hcl2nix.OCIArtifact{
 			{
-				Artifact: "pkgs",
-				Name:     "bsf-base-image",
-				Cmd:      []string{},
-				Entrypoint: []string{},
-				EnvVars:    []string{},
-				ExposedPorts: []string{},
+				Artifact:      "pkgs",
+				Name:          pd.Name,
+				Cmd:           []string{},
+				Entrypoint:    []string{},
+				EnvVars:       []string{},
+				ExposedPorts:  []string{},
 				ImportConfigs: []string{},
 			},
 		},
 	}
 }
-func genRustCargoConf() (hcl2nix.Config, error) {
+func genRustCargoConf(pd *langdetect.ProjectDetails) (hcl2nix.Config, error) {
+	if pd.Name == "" {
+		pd.Name = "expl"
+	}
 	content, err := os.ReadFile("Cargo.toml")
 	if err != nil {
 		return hcl2nix.Config{}, fmt.Errorf("error reading file: %v", err)
@@ -84,20 +92,23 @@ func genRustCargoConf() (hcl2nix.Config, error) {
 		},
 		OCIArtifact: []hcl2nix.OCIArtifact{
 			{
-				Artifact: "pkgs",
-				Name:     "bsf-base-image",
-				Cmd:      []string{},
-				Entrypoint: []string{},
-				EnvVars:    []string{},
-				ExposedPorts: []string{},
+				Artifact:      "pkgs",
+				Name:          pd.Name,
+				Cmd:           []string{},
+				Entrypoint:    []string{},
+				EnvVars:       []string{},
+				ExposedPorts:  []string{},
 				ImportConfigs: []string{},
 			},
 		},
 	}, nil
 }
 
-func genPythonPoetryConf() hcl2nix.Config {
+func genPythonPoetryConf(pd *langdetect.ProjectDetails) hcl2nix.Config {
 	// TODO: maybe we should note down the path of the poetry.lock file and use it here.
+	if pd.Name == "" {
+		pd.Name = "expl"
+	}
 	return hcl2nix.Config{
 		Packages: hcl2nix.Packages{
 			Development: []string{"python3@3.12.2", "poetry@1.8.2"},
@@ -113,12 +124,12 @@ func genPythonPoetryConf() hcl2nix.Config {
 		},
 		OCIArtifact: []hcl2nix.OCIArtifact{
 			{
-				Artifact: "pkgs",
-				Name:     "bsf-base-image",
-				Cmd:      []string{},
-				Entrypoint: []string{},
-				EnvVars:    []string{},
-				ExposedPorts: []string{},
+				Artifact:      "pkgs",
+				Name:          pd.Name,
+				Cmd:           []string{},
+				Entrypoint:    []string{},
+				EnvVars:       []string{},
+				ExposedPorts:  []string{},
 				ImportConfigs: []string{},
 			},
 		},
@@ -126,6 +137,9 @@ func genPythonPoetryConf() hcl2nix.Config {
 }
 
 func genGoModuleConf(pd *langdetect.ProjectDetails) hcl2nix.Config {
+	if pd.Name == "" {
+		pd.Name = "expl"
+	}
 	var name, entrypoint string
 	if pd != nil {
 		name = pd.Name
@@ -147,12 +161,12 @@ func genGoModuleConf(pd *langdetect.ProjectDetails) hcl2nix.Config {
 		},
 		OCIArtifact: []hcl2nix.OCIArtifact{
 			{
-				Artifact: "pkgs",
-				Name:     "bsf-base-image",
-				Cmd:      []string{},
-				Entrypoint: []string{},
-				EnvVars:    []string{},
-				ExposedPorts: []string{},
+				Artifact:      "pkgs",
+				Name:          pd.Name,
+				Cmd:           []string{},
+				Entrypoint:    []string{},
+				EnvVars:       []string{},
+				ExposedPorts:  []string{},
 				ImportConfigs: []string{},
 			},
 		},
@@ -160,7 +174,10 @@ func genGoModuleConf(pd *langdetect.ProjectDetails) hcl2nix.Config {
 
 }
 
-func genJsNpmConf() (hcl2nix.Config, error) {
+func genJsNpmConf(pd *langdetect.ProjectDetails) (hcl2nix.Config, error) {
+	if pd.Name == "" {
+		pd.Name = "expl"
+	}
 	data, err := os.ReadFile("package-lock.json")
 	if err != nil {
 		return hcl2nix.Config{}, fmt.Errorf("error reading file: %v", err)
@@ -186,12 +203,12 @@ func genJsNpmConf() (hcl2nix.Config, error) {
 		},
 		OCIArtifact: []hcl2nix.OCIArtifact{
 			{
-				Artifact: "pkgs",
-				Name:     "bsf-base-image",
-				Cmd:      []string{},
-				Entrypoint: []string{},
-				EnvVars:    []string{},
-				ExposedPorts: []string{},
+				Artifact:      "pkgs",
+				Name:          pd.Name,
+				Cmd:           []string{},
+				Entrypoint:    []string{},
+				EnvVars:       []string{},
+				ExposedPorts:  []string{},
 				ImportConfigs: []string{},
 			},
 		},

--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -107,9 +107,8 @@ func IOprompt(label string, defaultvalue any) any {
 		if s == "" {
 			return nil
 		}
-
-		return &s
 	}
+	return &s
 }
 
 // GetBSFInitializers generates the nix files

--- a/cmd/init/model.go
+++ b/cmd/init/model.go
@@ -90,7 +90,7 @@ func (m *model) processStages(stage int) error {
 		return nil
 	case 1:
 		// var err error
-		pt, pd, err := langdetect.FindProjectType()
+		pt, _, err := langdetect.FindProjectType()
 		if err != nil {
 			m.stageMsg = errorStyle(err.Error())
 			return err
@@ -100,7 +100,6 @@ func (m *model) processStages(stage int) error {
 			m.permMsg = errorStyle("Project language isn't currently supported. Some features might not work.")
 		}
 		m.pt = pt
-		m.pd = pd
 		return nil
 	case 2:
 		m.stageMsg = textStyle("Resolving dependencies... ")
@@ -116,7 +115,6 @@ func (m *model) processStages(stage int) error {
 		defer fh.LockFile.Close()
 		defer fh.FlakeFile.Close()
 		defer fh.DefFlakeFile.Close()
-
 		conf, err := generatehcl2NixConf(m.pt, m.pd)
 		if err != nil {
 			m.stageMsg = errorStyle(err.Error())


### PR DESCRIPTION
Closes #74 
Fixes #74 

## Description
This PR adds the feature of taking input prompts in the `bsf init` command.

## Additional Info
Looks something like this:
```powershell
lol@MSI:$ /bsf/main init
Running prechecks...
 ✅ Nix version is v2.21.2
 ✅ Flakes are enabled
 Prechecks ran successfully
Do you want docker file to be initialized (y/N) y
What should the name be? : myapp
```