### PR TITLE
feat: sort the dev and runtime packages in bsf.hcl

### DIFF
--- a/pkg/strings/set.go
+++ b/pkg/strings/set.go
@@ -1,5 +1,10 @@
 package strings
 
+import (
+	"sort"
+	"strings"
+)
+
 type parse func(string) string
 
 // SliceToSet converts a slice of strings to a set of strings
@@ -41,6 +46,10 @@ func PreferNewSliceElements(existing []string, new []string, parseFunc parse) []
 		}
 		finalEle = append(finalEle, v)
 	}
+
+	sort.Slice(finalEle, func(i, j int) bool {
+		return strings.Split(finalEle[i], "@")[0] < strings.Split(finalEle[j], "@")[0]
+	})
 
 	return finalEle
 }

--- a/pkg/strings/set_test.go
+++ b/pkg/strings/set_test.go
@@ -68,7 +68,7 @@ func TestPreferNewSliceElements(t *testing.T) {
 			name:     "Test 3",
 			existing: []string{"a", "b", "c"},
 			new:      []string{"a", "b", "d"},
-			want:     []string{"c", "a", "b", "d"},
+			want:     []string{"a", "b", "c", "d"},
 		},
 	}
 


### PR DESCRIPTION
Fixes #126 
Closes #126 

## Description
This PR sorts the Development and the Runtime packages present in the `bsf.hcl` in alphabetical order.
This works with both when the buildsafe is initialized and when packages are searched and added to the environment.

## Additional
There might be better way of implementing the `sortPackages` function in the `cmd\init\config.go`.
As the same logic is used on the both cases. We can put this function to `set.go` in `pkg\strings\set.go`